### PR TITLE
Fix AOS initialization check

### DIFF
--- a/app.js
+++ b/app.js
@@ -25,8 +25,10 @@ if (signupForm) {
   });
 }
 
-// Initialize AOS
-AOS.init();
+// Initialize AOS (only if the library is loaded)
+if (typeof AOS !== 'undefined') {
+  AOS.init();
+}
 
 // hamburger
 const burger = document.getElementById('burger');


### PR DESCRIPTION
## Summary
- avoid errors if the AOS library is missing by checking its presence

## Testing
- `npm test` *(fails: could not read `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6852c3ff370c8331b8dc75973db128ef